### PR TITLE
Resolve GitHub authentication issue in .gitmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/docopt.c"]
 	path = lib/docopt.c
-	url = git@github.com:docopt/docopt.c.git
+	url = https://github.com/docopt/docopt.c
 [submodule "lib/mbed-edge"]
-	url = git@github.com:ARMmbed/mbed-edge.git
 	path = lib/mbed-edge
+	url = https://github.com/ARMmbed/mbed-edge


### PR DESCRIPTION
Git-based urls will fail, if you have not authenticated to GitHub.